### PR TITLE
Fixed bug in goto() that caused pajinate to not honor "items_per_page" option.

### DIFF
--- a/jquery.pajinate.js
+++ b/jquery.pajinate.js
@@ -176,7 +176,7 @@
 			
 		function goto(page_num){
 			
-			var ipp = meta.data(items_per_page);
+			var ipp = parseInt(meta.data(items_per_page));
 			
 			var isLastPage = false;
 			


### PR DESCRIPTION
Fixed bug in goto() where the "ipp" variable was being concatenated with the "start_form" variable instead of being added to. A simple parseInt() did the trick...Did jQuery's element storage change recently?? 
