### PR TITLE
Added abort_on_small_lists option to disable pagination when the list is smaller than the number of items per page

### DIFF
--- a/examples/example1.html
+++ b/examples/example1.html
@@ -68,6 +68,13 @@
                     show_first_last: false
 				});
 			});               
+
+        	$(document).ready(function(){
+				$('#paging_container10').pajinate({
+                    items_per_page : 6,
+                    abort_on_small_lists: true
+				});
+			});               
 		</script>
 
 	</head>
@@ -315,6 +322,18 @@
 					 <li><p>Fourteen</p></li> 
 					 <li><p>Fifteen</p></li> 
 					 <li><p>Sixteen</p></li> 
+				</ul>	
+				
+			</div>            
+
+        	<div id="paging_container10" class="container">
+				<h2>Disable On Small Lists</h2>
+				<div class="page_navigation"></div>
+				
+				<ul class="content">
+					 <li><p>One</p></li> 
+					 <li><p>Two</p></li> 
+					 <li><p>Three</p></li> 
 				</ul>	
 				
 			</div>            

--- a/examples/js/jquery.pajinate.js
+++ b/examples/js/jquery.pajinate.js
@@ -11,7 +11,7 @@
 
     $.fn.pajinate = function(options){
         // Set some state information
-    	var current_page = 'current_page';
+        var current_page = 'current_page';
 		var items_per_page = 'items_per_page';
 		
 		var meta;
@@ -28,7 +28,8 @@
 			nav_label_prev : 'Prev',
 			nav_label_next : 'Next',
 			nav_label_last : 'Last',
-            show_first_last: true
+            show_first_last: true,
+            abort_on_small_lists: false
 		};
 		var options = $.extend(defaults,options);
 		var $item_container;
@@ -41,6 +42,10 @@
 			$page_container = $(this);
 			$item_container = $(this).find(options.item_container_id);
 			$items = $page_container.find(options.item_container_id).children();
+            
+            if (options.abort_on_small_lists && options.items_per_page >= $items.size())
+                return $page_container;
+
 			meta = $page_container;
 			
 			// Initialise meta data
@@ -176,7 +181,7 @@
 			
 		function goto(page_num){
 			
-			var ipp = meta.data(items_per_page);
+			var ipp = parseInt(meta.data(items_per_page));
 			
 			var isLastPage = false;
 			

--- a/jquery.pajinate.js
+++ b/jquery.pajinate.js
@@ -28,7 +28,8 @@
 			nav_label_prev : 'Prev',
 			nav_label_next : 'Next',
 			nav_label_last : 'Last',
-            show_first_last: true
+            show_first_last: true,
+            abort_on_small_lists: false
 		};
 		var options = $.extend(defaults,options);
 		var $item_container;
@@ -41,6 +42,10 @@
 			$page_container = $(this);
 			$item_container = $(this).find(options.item_container_id);
 			$items = $page_container.find(options.item_container_id).children();
+            
+            if (options.abort_on_small_lists && options.items_per_page >= $items.size())
+                return $page_container;
+
 			meta = $page_container;
 			
 			// Initialise meta data


### PR DESCRIPTION
If abort_on_small lists is set to true and the number of items in the list is less than the number of items to display per page, don't paginate.
