### PR TITLE
Fixed $nav_panels variable usage (instead of navigating from parent containers)

### DIFF
--- a/jquery.pajinate.js
+++ b/jquery.pajinate.js
@@ -129,7 +129,7 @@
 
 			/* Setup Nav Menu Display */
 			// Page number slices
-			total_page_no_links = $page_container.children(options.nav_panel_id + ':first').children('.page_link').size();
+			total_page_no_links = $nav_panels.children('.page_link').size();
 			options.num_page_links_to_display = Math.min(options.num_page_links_to_display, total_page_no_links);
 
 			$nav_panels.children('.page_link').hide(); // Hide all the page links
@@ -224,7 +224,7 @@
 			items.show();
 
 			// Reassign the active class
-			$page_container.find(options.nav_panel_id).children('.page_link[longdesc=' + page_num + ']').addClass('active_page ' + jquery_ui_active_class).siblings('.active_page').removeClass('active_page ' + jquery_ui_active_class);
+			$nav_panels.children('.page_link[longdesc=' + page_num + ']').addClass('active_page ' + jquery_ui_active_class).siblings('.active_page').removeClass('active_page ' + jquery_ui_active_class);
 
 			// Set the current page meta data							
 			meta.data(current_page, page_num);


### PR DESCRIPTION
Hi,

I was customizing your plugin to make it compatible with [Twitter Bootstrap's pagination component](http://twitter.github.com/bootstrap/components.html#pagination). It appears to me than $nav_panels variable could be used in two places, where you choose to navigate from top-level container instead.
It's a dummy pull-request, but it enables me to customize more easily $nav_panels content.

Hope this pull-request won't lost much of your time.
