### PR TITLE
There was a bug using lists with dynamic items number

### DIFF
--- a/jquery.pajinate.js
+++ b/jquery.pajinate.js
@@ -55,7 +55,11 @@
 			$item_container = $(this).find(options.item_container_id);
 			$items = $page_container.find(options.item_container_id).children();
 
-			if (options.abort_on_small_lists && options.items_per_page >= $items.size()) return $page_container;
+			if (options.abort_on_small_lists && (options.items_per_page >= $items.size())){
+                        $nav_panels = $page_container.find(options.nav_panel_id);			
+			$nav_panels.html('');
+                        return $page_container;
+			}
 
 			meta = $page_container;
 


### PR DESCRIPTION
It's necessary to delete the navigation bar when you are using
abort_on_small_lists with dynamic lists.
